### PR TITLE
Code formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+plugins {
+    id "com.diffplug.gradle.spotless" version "3.5.2"
+}
+
 group = 'io.kamax'
 version = '0.0.2'
 
@@ -65,5 +69,21 @@ uploadArchives {
                     privateKey: gradle.mavenPrivateKey
             )
         }
+    }
+}
+
+// Settings for automatic code formatting
+compileJava.dependsOn { spotlessApply }
+
+spotless {
+    format 'misc', {
+        target '**/*.gradle', '**/*.md', '**/.gitignore'
+
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+    }
+    java {
+        eclipse().configFile 'spotless.eclipseformat.xml'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -85,5 +85,7 @@ spotless {
     }
     java {
         eclipse().configFile 'spotless.eclipseformat.xml'
+        removeUnusedImports()
+        importOrderFile 'spotless.importorder'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -72,9 +72,6 @@ uploadArchives {
     }
 }
 
-// Settings for automatic code formatting
-compileJava.dependsOn { spotlessApply }
-
 spotless {
     format 'misc', {
         target '**/*.gradle', '**/*.md', '**/.gitignore'

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,4 +19,3 @@
  */
 
 rootProject.name = 'matrix-java-sdk'
-

--- a/spotless.eclipseformat.xml
+++ b/spotless.eclipseformat.xml
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="matrix-java-sdk" version="13">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>

--- a/spotless.eclipseformat.xml
+++ b/spotless.eclipseformat.xml
@@ -155,7 +155,7 @@
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>

--- a/spotless.eclipseformat.xml
+++ b/spotless.eclipseformat.xml
@@ -72,7 +72,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
 <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
@@ -307,7 +307,7 @@
 <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
 </profile>

--- a/spotless.importorder
+++ b/spotless.importorder
@@ -1,0 +1,8 @@
+#Organize Import Order
+#Fri Sep 22 19:44:55 CEST 2017
+5=\#org
+4=javax
+3=java
+2=org
+1=io
+0=com

--- a/src/main/java/io/kamax/matrix/MatrixErrorInfo.java
+++ b/src/main/java/io/kamax/matrix/MatrixErrorInfo.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/MatrixID.java
+++ b/src/main/java/io/kamax/matrix/MatrixID.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/ThreePid.java
+++ b/src/main/java/io/kamax/matrix/ThreePid.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/ThreePidMapping.java
+++ b/src/main/java/io/kamax/matrix/ThreePidMapping.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/ThreePidMedium.java
+++ b/src/main/java/io/kamax/matrix/ThreePidMedium.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/_MatrixContent.java
+++ b/src/main/java/io/kamax/matrix/_MatrixContent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/_MatrixID.java
+++ b/src/main/java/io/kamax/matrix/_MatrixID.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/_MatrixID.java
+++ b/src/main/java/io/kamax/matrix/_MatrixID.java
@@ -29,21 +29,24 @@ public interface _MatrixID {
     String getDomain();
 
     /**
-     * Render this Matrix ID strictly valid. In technical term, transform this ID so <code>isValid()</code> returns true.
+     * Render this Matrix ID strictly valid. In technical term, transform this ID so
+     * <code>isValid()</code> returns true.
      *
      * @return A canonical Matrix ID
      */
     _MatrixID canonicalize();
 
     /**
-     * If the Matrix ID is strictly valid in the protocol as per http://matrix.org/docs/spec/intro.html#user-identifiers
+     * If the Matrix ID is strictly valid in the protocol as per
+     * http://matrix.org/docs/spec/intro.html#user-identifiers
      *
      * @return true if strictly valid, false if not
      */
     boolean isValid();
 
     /**
-     * If the Matrix ID is acceptable in the protocol as per http://matrix.org/docs/spec/intro.html#historical-user-ids
+     * If the Matrix ID is acceptable in the protocol as per
+     * http://matrix.org/docs/spec/intro.html#historical-user-ids
      *
      * @return
      */

--- a/src/main/java/io/kamax/matrix/_MatrixUser.java
+++ b/src/main/java/io/kamax/matrix/_MatrixUser.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/_ThreePid.java
+++ b/src/main/java/io/kamax/matrix/_ThreePid.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/_ThreePidMapping.java
+++ b/src/main/java/io/kamax/matrix/_ThreePidMapping.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
@@ -129,8 +129,7 @@ public abstract class AMatrixHttpClient implements _MatrixClientRaw {
     }
 
     protected HttpEntity getJsonEntity(Object o) {
-        return EntityBuilder.create().setText(gson.toJson(o))
-                .setContentType(ContentType.APPLICATION_JSON).build();
+        return EntityBuilder.create().setText(gson.toJson(o)).setContentType(ContentType.APPLICATION_JSON).build();
     }
 
 }

--- a/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
@@ -22,8 +22,10 @@ package io.kamax.matrix.client;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
+
 import io.kamax.matrix._MatrixID;
 import io.kamax.matrix.hs._MatrixHomeserver;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.client.entity.EntityBuilder;
 import org.apache.http.client.methods.HttpRequestBase;

--- a/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/AMatrixHttpClient.java
@@ -127,10 +127,8 @@ public abstract class AMatrixHttpClient implements _MatrixClientRaw {
     }
 
     protected HttpEntity getJsonEntity(Object o) {
-        return EntityBuilder.create()
-                .setText(gson.toJson(o))
-                .setContentType(ContentType.APPLICATION_JSON)
-                .build();
+        return EntityBuilder.create().setText(gson.toJson(o))
+                .setContentType(ContentType.APPLICATION_JSON).build();
     }
 
 }

--- a/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
@@ -34,7 +34,8 @@ public class MatrixClientContext {
         this(hs, user, token, false);
     }
 
-    public MatrixClientContext(_MatrixHomeserver hs, _MatrixID user, String token, boolean isVirtualUser) {
+    public MatrixClientContext(_MatrixHomeserver hs, _MatrixID user, String token,
+            boolean isVirtualUser) {
         this.hs = hs;
         this.user = user;
         this.token = token;

--- a/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixClientContext.java
@@ -34,8 +34,7 @@ public class MatrixClientContext {
         this(hs, user, token, false);
     }
 
-    public MatrixClientContext(_MatrixHomeserver hs, _MatrixID user, String token,
-            boolean isVirtualUser) {
+    public MatrixClientContext(_MatrixHomeserver hs, _MatrixID user, String token, boolean isVirtualUser) {
         this.hs = hs;
         this.user = user;
         this.token = token;

--- a/src/main/java/io/kamax/matrix/client/MatrixClientRequestException.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixClientRequestException.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
@@ -22,6 +22,7 @@ package io.kamax.matrix.client;
 
 import io.kamax.matrix.MatrixErrorInfo;
 import io.kamax.matrix._MatrixContent;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
@@ -68,8 +68,7 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
 
         try {
             if (!StringUtils.equalsIgnoreCase("mxc", address.getScheme())) {
-                log.error("{} is not a supported protocol for avatars, ignoring",
-                        address.getScheme());
+                log.error("{} is not a supported protocol for avatars, ignoring", address.getScheme());
             } else {
                 URI path = getMediaPath("/download/" + address.getHost() + address.getPath());
                 try (CloseableHttpResponse res = client.execute(log(new HttpGet(path)))) {
@@ -78,13 +77,12 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
                             log.info("Media {} does not exist on the HS {}", address.toString(),
                                     getContext().getHs().getDomain());
                         } else {
-                            Charset charset = ContentType.getOrDefault(res.getEntity())
-                                    .getCharset();
+                            Charset charset = ContentType.getOrDefault(res.getEntity()).getCharset();
                             String body = IOUtils.toString(res.getEntity().getContent(), charset);
 
                             MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                            log.error("Couldn't get content data for {}: {} - {}",
-                                    address.toString(), info.getErrcode(), info.getError());
+                            log.error("Couldn't get content data for {}: {} - {}", address.toString(),
+                                    info.getErrcode(), info.getError());
                         }
                     } else {
                         HttpEntity entity = res.getEntity();
@@ -93,8 +91,7 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
                         } else {
                             Header contentType = entity.getContentType();
                             if (contentType == null) {
-                                log.info(
-                                        "No content type was given, unable to process avatar data");
+                                log.info("No content type was given, unable to process avatar data");
                             } else {
                                 type = contentType.getValue();
                                 ByteArrayOutputStream outStream = new ByteArrayOutputStream();
@@ -102,11 +99,9 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
                                 data = outStream.toByteArray();
                                 isValid = true;
 
-                                Header contentDisposition = res
-                                        .getFirstHeader("Content-Disposition");
+                                Header contentDisposition = res.getFirstHeader("Content-Disposition");
                                 if (contentDisposition != null) {
-                                    Matcher m = filenamePattern
-                                            .matcher(contentDisposition.getValue());
+                                    Matcher m = filenamePattern.matcher(contentDisposition.getValue());
                                     if (m.find()) {
                                         filename = m.group("filename");
                                     }

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
@@ -67,19 +67,23 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
 
         try {
             if (!StringUtils.equalsIgnoreCase("mxc", address.getScheme())) {
-                log.error("{} is not a supported protocol for avatars, ignoring", address.getScheme());
+                log.error("{} is not a supported protocol for avatars, ignoring",
+                        address.getScheme());
             } else {
                 URI path = getMediaPath("/download/" + address.getHost() + address.getPath());
                 try (CloseableHttpResponse res = client.execute(log(new HttpGet(path)))) {
                     if (res.getStatusLine().getStatusCode() != 200) {
                         if (res.getStatusLine().getStatusCode() == 404) {
-                            log.info("Media {} does not exist on the HS {}", address.toString(), getContext().getHs().getDomain());
+                            log.info("Media {} does not exist on the HS {}", address.toString(),
+                                    getContext().getHs().getDomain());
                         } else {
-                            Charset charset = ContentType.getOrDefault(res.getEntity()).getCharset();
+                            Charset charset = ContentType.getOrDefault(res.getEntity())
+                                    .getCharset();
                             String body = IOUtils.toString(res.getEntity().getContent(), charset);
 
                             MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                            log.error("Couldn't get content data for {}: {} - {}", address.toString(), info.getErrcode(), info.getError());
+                            log.error("Couldn't get content data for {}: {} - {}",
+                                    address.toString(), info.getErrcode(), info.getError());
                         }
                     } else {
                         HttpEntity entity = res.getEntity();
@@ -88,7 +92,8 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
                         } else {
                             Header contentType = entity.getContentType();
                             if (contentType == null) {
-                                log.info("No content type was given, unable to process avatar data");
+                                log.info(
+                                        "No content type was given, unable to process avatar data");
                             } else {
                                 type = contentType.getValue();
                                 ByteArrayOutputStream outStream = new ByteArrayOutputStream();
@@ -96,9 +101,11 @@ public class MatrixHttpContent extends AMatrixHttpClient implements _MatrixConte
                                 data = outStream.toByteArray();
                                 isValid = true;
 
-                                Header contentDisposition = res.getFirstHeader("Content-Disposition");
+                                Header contentDisposition = res
+                                        .getFirstHeader("Content-Disposition");
                                 if (contentDisposition != null) {
-                                    Matcher m = filenamePattern.matcher(contentDisposition.getValue());
+                                    Matcher m = filenamePattern
+                                            .matcher(contentDisposition.getValue());
                                     if (m.find()) {
                                         filename = m.group("filename");
                                     }

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpContent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
@@ -90,10 +90,12 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new IOException("Couldn't get name for room " + roomId + " - " + info.getErrcode() + ": " + info.getError());
+                    throw new IOException("Couldn't get name for room " + roomId + " - "
+                            + info.getErrcode() + ": " + info.getError());
                 }
 
-                return Optional.of(jsonParser.parse(body).getAsJsonObject().get("name").getAsString());
+                return Optional
+                        .of(jsonParser.parse(body).getAsJsonObject().get("name").getAsString());
             }
         } catch (IOException e) {
             throw new MatrixClientRequestException(e);
@@ -120,10 +122,12 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new MatrixClientRequestException(info, "Couldn't get topic for room " + roomId);
+                    throw new MatrixClientRequestException(info,
+                            "Couldn't get topic for room " + roomId);
                 }
 
-                return Optional.of(jsonParser.parse(body).getAsJsonObject().get("topic").getAsString());
+                return Optional
+                        .of(jsonParser.parse(body).getAsJsonObject().get("topic").getAsString());
             }
         } catch (IOException e) {
             throw new MatrixClientRequestException(e);
@@ -151,7 +155,8 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                 MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
 
                 if (res.getStatusLine().getStatusCode() == 403) {
-                    log.error("Failed to join room, we are not allowed: {} - {}", info.getErrcode(), info.getError());
+                    log.error("Failed to join room, we are not allowed: {} - {}", info.getErrcode(),
+                            info.getError());
                 } else {
                     throw new MatrixClientRequestException(info, "Error joining for " + getUser());
                 }
@@ -188,9 +193,12 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
 
                     if (res.getStatusLine().getStatusCode() == 403) {
-                        log.debug("Failed to leave room, we are not allowed, most likely already left: {} - {}", info.getErrcode(), info.getError());
+                        log.debug(
+                                "Failed to leave room, we are not allowed, most likely already left: {} - {}",
+                                info.getErrcode(), info.getError());
                     } else {
-                        throw new MatrixClientRequestException(info, "Error when leaving room " + roomId + " as " + getUser());
+                        throw new MatrixClientRequestException(info,
+                                "Error when leaving room " + roomId + " as " + getUser());
                     }
                 }
             }
@@ -201,7 +209,8 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
 
     private void sendMessage(RoomMessageTextPutBody content) {
         try {
-            URI path = getClientPath("/rooms/{roomId}/send/m.room.message/" + System.currentTimeMillis());
+            URI path = getClientPath(
+                    "/rooms/{roomId}/send/m.room.message/" + System.currentTimeMillis());
             HttpPut req = new HttpPut(path);
             req.setEntity(getJsonEntity(content));
 
@@ -221,7 +230,8 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                     if (res.getStatusLine().getStatusCode() == 403) {
                         log.error("Failed send message, we are not allowed: {}", info.getError());
                     } else {
-                        throw new IOException("Error sending message for " + getUser() + " - " + info.getErrcode() + ": " + info.getError());
+                        throw new IOException("Error sending message for " + getUser() + " - "
+                                + info.getErrcode() + ": " + info.getError());
                     }
                 }
             }
@@ -273,10 +283,12 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new IOException("Couldn't list joined users in " + roomId + " - " + info.getErrcode() + ": " + info.getError());
+                    throw new IOException("Couldn't list joined users in " + roomId + " - "
+                            + info.getErrcode() + ": " + info.getError());
                 }
 
-                JsonObject joinedUsers = jsonParser.parse(body).getAsJsonObject().get("joined").getAsJsonObject();
+                JsonObject joinedUsers = jsonParser.parse(body).getAsJsonObject().get("joined")
+                        .getAsJsonObject();
                 List<_MatrixID> ids = new ArrayList<>();
                 for (Map.Entry<String, JsonElement> entry : joinedUsers.entrySet()) {
                     ids.add(new MatrixID(entry.getKey()));

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
@@ -92,12 +92,11 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new IOException("Couldn't get name for room " + roomId + " - "
-                            + info.getErrcode() + ": " + info.getError());
+                    throw new IOException("Couldn't get name for room " + roomId + " - " + info.getErrcode() + ": "
+                            + info.getError());
                 }
 
-                return Optional
-                        .of(jsonParser.parse(body).getAsJsonObject().get("name").getAsString());
+                return Optional.of(jsonParser.parse(body).getAsJsonObject().get("name").getAsString());
             }
         } catch (IOException e) {
             throw new MatrixClientRequestException(e);
@@ -124,12 +123,10 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new MatrixClientRequestException(info,
-                            "Couldn't get topic for room " + roomId);
+                    throw new MatrixClientRequestException(info, "Couldn't get topic for room " + roomId);
                 }
 
-                return Optional
-                        .of(jsonParser.parse(body).getAsJsonObject().get("topic").getAsString());
+                return Optional.of(jsonParser.parse(body).getAsJsonObject().get("topic").getAsString());
             }
         } catch (IOException e) {
             throw new MatrixClientRequestException(e);
@@ -157,8 +154,7 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                 MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
 
                 if (res.getStatusLine().getStatusCode() == 403) {
-                    log.error("Failed to join room, we are not allowed: {} - {}", info.getErrcode(),
-                            info.getError());
+                    log.error("Failed to join room, we are not allowed: {} - {}", info.getErrcode(), info.getError());
                 } else {
                     throw new MatrixClientRequestException(info, "Error joining for " + getUser());
                 }
@@ -195,8 +191,7 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
 
                     if (res.getStatusLine().getStatusCode() == 403) {
-                        log.debug(
-                                "Failed to leave room, we are not allowed, most likely already left: {} - {}",
+                        log.debug("Failed to leave room, we are not allowed, most likely already left: {} - {}",
                                 info.getErrcode(), info.getError());
                     } else {
                         throw new MatrixClientRequestException(info,
@@ -211,8 +206,7 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
 
     private void sendMessage(RoomMessageTextPutBody content) {
         try {
-            URI path = getClientPath(
-                    "/rooms/{roomId}/send/m.room.message/" + System.currentTimeMillis());
+            URI path = getClientPath("/rooms/{roomId}/send/m.room.message/" + System.currentTimeMillis());
             HttpPut req = new HttpPut(path);
             req.setEntity(getJsonEntity(content));
 
@@ -232,8 +226,8 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                     if (res.getStatusLine().getStatusCode() == 403) {
                         log.error("Failed send message, we are not allowed: {}", info.getError());
                     } else {
-                        throw new IOException("Error sending message for " + getUser() + " - "
-                                + info.getErrcode() + ": " + info.getError());
+                        throw new IOException("Error sending message for " + getUser() + " - " + info.getErrcode()
+                                + ": " + info.getError());
                     }
                 }
             }
@@ -285,12 +279,11 @@ public class MatrixHttpRoom extends AMatrixHttpClient implements _MatrixRoom {
                         log.warn("Request was rate limited", new Exception());
                     }
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new IOException("Couldn't list joined users in " + roomId + " - "
-                            + info.getErrcode() + ": " + info.getError());
+                    throw new IOException("Couldn't list joined users in " + roomId + " - " + info.getErrcode() + ": "
+                            + info.getError());
                 }
 
-                JsonObject joinedUsers = jsonParser.parse(body).getAsJsonObject().get("joined")
-                        .getAsJsonObject();
+                JsonObject joinedUsers = jsonParser.parse(body).getAsJsonObject().get("joined").getAsJsonObject();
                 List<_MatrixID> ids = new ArrayList<>();
                 for (Map.Entry<String, JsonElement> entry : joinedUsers.entrySet()) {
                     ids.add(new MatrixID(entry.getKey()));

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpRoom.java
@@ -22,12 +22,14 @@ package io.kamax.matrix.client;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.MatrixErrorInfo;
 import io.kamax.matrix.MatrixID;
 import io.kamax.matrix._MatrixID;
 import io.kamax.matrix.hs._MatrixRoom;
 import io.kamax.matrix.json.RoomMessageFormattedTextPutBody;
 import io.kamax.matrix.json.RoomMessageTextPutBody;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
@@ -78,8 +78,7 @@ public class MatrixHttpUser extends AMatrixHttpClient implements _MatrixUser {
                     }
 
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    log.error("Couldn't get the displayname of {}: {} - {}", mxId,
-                            info.getErrcode(), info.getError());
+                    log.error("Couldn't get the displayname of {}: {} - {}", mxId, info.getErrcode(), info.getError());
                     return Optional.empty();
                 }
 
@@ -117,8 +116,7 @@ public class MatrixHttpUser extends AMatrixHttpClient implements _MatrixUser {
                     }
 
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    log.error("Couldn't get the avatar_url of {}: {} - {}", mxId, info.getErrcode(),
-                            info.getError());
+                    log.error("Couldn't get the avatar_url of {}: {} - {}", mxId, info.getErrcode(), info.getError());
                     return Optional.empty();
                 }
 

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
@@ -76,7 +76,8 @@ public class MatrixHttpUser extends AMatrixHttpClient implements _MatrixUser {
                     }
 
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    log.error("Couldn't get the displayname of {}: {} - {}", mxId, info.getErrcode(), info.getError());
+                    log.error("Couldn't get the displayname of {}: {} - {}", mxId,
+                            info.getErrcode(), info.getError());
                     return Optional.empty();
                 }
 
@@ -114,7 +115,8 @@ public class MatrixHttpUser extends AMatrixHttpClient implements _MatrixUser {
                     }
 
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    log.error("Couldn't get the avatar_url of {}: {} - {}", mxId, info.getErrcode(), info.getError());
+                    log.error("Couldn't get the avatar_url of {}: {} - {}", mxId, info.getErrcode(),
+                            info.getError());
                     return Optional.empty();
                 }
 

--- a/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpUser.java
@@ -21,10 +21,12 @@
 package io.kamax.matrix.client;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.MatrixErrorInfo;
 import io.kamax.matrix._MatrixContent;
 import io.kamax.matrix._MatrixID;
 import io.kamax.matrix._MatrixUser;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/src/main/java/io/kamax/matrix/client/_MatrixClient.java
+++ b/src/main/java/io/kamax/matrix/client/_MatrixClient.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/_MatrixClientRaw.java
+++ b/src/main/java/io/kamax/matrix/client/_MatrixClientRaw.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client;

--- a/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
+++ b/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client.as;

--- a/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
+++ b/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
@@ -28,6 +28,7 @@ import io.kamax.matrix.client._MatrixClient;
 import io.kamax.matrix.client.regular.MatrixHttpClient;
 import io.kamax.matrix.hs._MatrixHomeserver;
 import io.kamax.matrix.json.VirtualUserRegistrationBody;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;

--- a/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
+++ b/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
@@ -40,8 +40,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 
-public class MatrixApplicationServiceClient extends MatrixHttpClient
-        implements _MatrixApplicationServiceClient {
+public class MatrixApplicationServiceClient extends MatrixHttpClient implements _MatrixApplicationServiceClient {
 
     private Logger log = LoggerFactory.getLogger(MatrixApplicationServiceClient.class);
 
@@ -50,8 +49,8 @@ public class MatrixApplicationServiceClient extends MatrixHttpClient
     }
 
     private MatrixHttpClient createClient(String localpart) {
-        return new MatrixHttpClient(new MatrixClientContext(getHomeserver(), getMatrixId(localpart),
-                getAccessToken(), true));
+        return new MatrixHttpClient(
+                new MatrixClientContext(getHomeserver(), getMatrixId(localpart), getAccessToken(), true));
     }
 
     @Override
@@ -73,8 +72,7 @@ public class MatrixApplicationServiceClient extends MatrixHttpClient
                         log.warn("User {} already exists, ignoring", localpart);
                     } else {
                         // TODO turn into dedicated exceptions, following the Spec distinct errors
-                        throw new MatrixClientRequestException(info,
-                                "Error creating the new user " + localpart);
+                        throw new MatrixClientRequestException(info, "Error creating the new user " + localpart);
                     }
                 }
             }

--- a/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
+++ b/src/main/java/io/kamax/matrix/client/as/MatrixApplicationServiceClient.java
@@ -39,7 +39,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 
-public class MatrixApplicationServiceClient extends MatrixHttpClient implements _MatrixApplicationServiceClient {
+public class MatrixApplicationServiceClient extends MatrixHttpClient
+        implements _MatrixApplicationServiceClient {
 
     private Logger log = LoggerFactory.getLogger(MatrixApplicationServiceClient.class);
 
@@ -48,7 +49,8 @@ public class MatrixApplicationServiceClient extends MatrixHttpClient implements 
     }
 
     private MatrixHttpClient createClient(String localpart) {
-        return new MatrixHttpClient(new MatrixClientContext(getHomeserver(), getMatrixId(localpart), getAccessToken(), true));
+        return new MatrixHttpClient(new MatrixClientContext(getHomeserver(), getMatrixId(localpart),
+                getAccessToken(), true));
     }
 
     @Override
@@ -70,7 +72,8 @@ public class MatrixApplicationServiceClient extends MatrixHttpClient implements 
                         log.warn("User {} already exists, ignoring", localpart);
                     } else {
                         // TODO turn into dedicated exceptions, following the Spec distinct errors
-                        throw new MatrixClientRequestException(info, "Error creating the new user " + localpart);
+                        throw new MatrixClientRequestException(info,
+                                "Error creating the new user " + localpart);
                     }
                 }
             }

--- a/src/main/java/io/kamax/matrix/client/as/_MatrixApplicationServiceClient.java
+++ b/src/main/java/io/kamax/matrix/client/as/_MatrixApplicationServiceClient.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client.as;

--- a/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.client.regular;

--- a/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
@@ -27,6 +27,7 @@ import io.kamax.matrix._MatrixUser;
 import io.kamax.matrix.client.*;
 import io.kamax.matrix.hs._MatrixRoom;
 import io.kamax.matrix.json.UserDisplaynameSetBody;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;

--- a/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
@@ -70,8 +70,7 @@ public class MatrixHttpClient extends AMatrixHttpClient implements _MatrixClient
                     Charset charset = ContentType.getOrDefault(res.getEntity()).getCharset();
                     String body = IOUtils.toString(res.getEntity().getContent(), charset);
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new MatrixClientRequestException(info,
-                            "Error changing display name for " + getUser());
+                    throw new MatrixClientRequestException(info, "Error changing display name for " + getUser());
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
@@ -69,7 +69,8 @@ public class MatrixHttpClient extends AMatrixHttpClient implements _MatrixClient
                     Charset charset = ContentType.getOrDefault(res.getEntity()).getCharset();
                     String body = IOUtils.toString(res.getEntity().getContent(), charset);
                     MatrixErrorInfo info = gson.fromJson(body, MatrixErrorInfo.class);
-                    throw new MatrixClientRequestException(info, "Error changing display name for " + getUser());
+                    throw new MatrixClientRequestException(info,
+                            "Error changing display name for " + getUser());
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/io/kamax/matrix/event/_MatrixEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_MatrixEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.event;

--- a/src/main/java/io/kamax/matrix/event/_RoomEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_RoomEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.event;

--- a/src/main/java/io/kamax/matrix/event/_RoomEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_RoomEvent.java
@@ -20,7 +20,6 @@
 
 package io.kamax.matrix.event;
 
-
 public interface _RoomEvent extends _MatrixEvent {
 
     String getRoomId();

--- a/src/main/java/io/kamax/matrix/event/_RoomMembershipEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_RoomMembershipEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.event;

--- a/src/main/java/io/kamax/matrix/event/_RoomMessageEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_RoomMessageEvent.java
@@ -20,7 +20,6 @@
 
 package io.kamax.matrix.event;
 
-
 public interface _RoomMessageEvent extends _RoomEvent {
 
     String getBody();

--- a/src/main/java/io/kamax/matrix/event/_RoomMessageEvent.java
+++ b/src/main/java/io/kamax/matrix/event/_RoomMessageEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.event;

--- a/src/main/java/io/kamax/matrix/hs/MatrixHomeserver.java
+++ b/src/main/java/io/kamax/matrix/hs/MatrixHomeserver.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.hs;

--- a/src/main/java/io/kamax/matrix/hs/RoomMembership.java
+++ b/src/main/java/io/kamax/matrix/hs/RoomMembership.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.hs;

--- a/src/main/java/io/kamax/matrix/hs/_MatrixHomeserver.java
+++ b/src/main/java/io/kamax/matrix/hs/_MatrixHomeserver.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.hs;

--- a/src/main/java/io/kamax/matrix/hs/_MatrixRoom.java
+++ b/src/main/java/io/kamax/matrix/hs/_MatrixRoom.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.hs;

--- a/src/main/java/io/kamax/matrix/is/_IdentityServer.java
+++ b/src/main/java/io/kamax/matrix/is/_IdentityServer.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.is;

--- a/src/main/java/io/kamax/matrix/json/MatrixJsonEventFactory.java
+++ b/src/main/java/io/kamax/matrix/json/MatrixJsonEventFactory.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/MatrixJsonEventFactory.java
+++ b/src/main/java/io/kamax/matrix/json/MatrixJsonEventFactory.java
@@ -21,6 +21,7 @@
 package io.kamax.matrix.json;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.event._MatrixEvent;
 import io.kamax.matrix.json.event.MatrixJsonEvent;
 import io.kamax.matrix.json.event.MatrixJsonRoomMembershipEvent;

--- a/src/main/java/io/kamax/matrix/json/MatrixJsonObject.java
+++ b/src/main/java/io/kamax/matrix/json/MatrixJsonObject.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/RoomMessageFormattedTextPutBody.java
+++ b/src/main/java/io/kamax/matrix/json/RoomMessageFormattedTextPutBody.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/RoomMessageTextPutBody.java
+++ b/src/main/java/io/kamax/matrix/json/RoomMessageTextPutBody.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/UserDisplaynameSetBody.java
+++ b/src/main/java/io/kamax/matrix/json/UserDisplaynameSetBody.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/VirtualUserRegistrationBody.java
+++ b/src/main/java/io/kamax/matrix/json/VirtualUserRegistrationBody.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
@@ -20,7 +20,6 @@
 
 package io.kamax.matrix.json.event;
 
-
 import com.google.gson.JsonObject;
 import io.kamax.matrix.MatrixID;
 import io.kamax.matrix._MatrixID;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json.event;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonEvent.java
@@ -21,6 +21,7 @@
 package io.kamax.matrix.json.event;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.MatrixID;
 import io.kamax.matrix._MatrixID;
 import io.kamax.matrix.event._MatrixEvent;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json.event;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomEvent.java
@@ -21,6 +21,7 @@
 package io.kamax.matrix.json.event;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.event._RoomEvent;
 
 public class MatrixJsonRoomEvent extends MatrixJsonEvent implements _RoomEvent {

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
@@ -29,8 +29,7 @@ import io.kamax.matrix.json.MatrixJsonObject;
 
 import java.util.Optional;
 
-public class MatrixJsonRoomMembershipEvent extends MatrixJsonRoomEvent
-        implements _RoomMembershipEvent {
+public class MatrixJsonRoomMembershipEvent extends MatrixJsonRoomEvent implements _RoomMembershipEvent {
 
     private Content content;
     private _MatrixID invitee;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json.event;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
@@ -28,7 +28,8 @@ import io.kamax.matrix.json.MatrixJsonObject;
 
 import java.util.Optional;
 
-public class MatrixJsonRoomMembershipEvent extends MatrixJsonRoomEvent implements _RoomMembershipEvent {
+public class MatrixJsonRoomMembershipEvent extends MatrixJsonRoomEvent
+        implements _RoomMembershipEvent {
 
     private Content content;
     private _MatrixID invitee;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMembershipEvent.java
@@ -21,6 +21,7 @@
 package io.kamax.matrix.json.event;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.MatrixID;
 import io.kamax.matrix._MatrixID;
 import io.kamax.matrix.event._RoomMembershipEvent;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMessageEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMessageEvent.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix.json.event;

--- a/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMessageEvent.java
+++ b/src/main/java/io/kamax/matrix/json/event/MatrixJsonRoomMessageEvent.java
@@ -21,6 +21,7 @@
 package io.kamax.matrix.json.event;
 
 import com.google.gson.JsonObject;
+
 import io.kamax.matrix.event._RoomMessageEvent;
 
 public class MatrixJsonRoomMessageEvent extends MatrixJsonRoomEvent implements _RoomMessageEvent {

--- a/src/test/java/io/kamax/matrix/LoggingDependencyTest.java
+++ b/src/test/java/io/kamax/matrix/LoggingDependencyTest.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package io.kamax.matrix;
 

--- a/src/test/java/io/kamax/matrix/MatrixIDTest.java
+++ b/src/test/java/io/kamax/matrix/MatrixIDTest.java
@@ -36,7 +36,6 @@ public class MatrixIDTest {
     private static String invalidMxId4 = "@:";
     private static String invalidMxId5 = "@john.doe:";
 
-
     @Test
     public void validMatrixIDs() {
         _MatrixID mxId1 = new MatrixID(validMxId1);

--- a/src/test/java/io/kamax/matrix/MatrixIDTest.java
+++ b/src/test/java/io/kamax/matrix/MatrixIDTest.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;

--- a/src/test/java/io/kamax/matrix/ThreePidTest.java
+++ b/src/test/java/io/kamax/matrix/ThreePidTest.java
@@ -11,11 +11,11 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 package io.kamax.matrix;


### PR DESCRIPTION
I've added the spotless plugin for code formatting to the project. Travis-CI fails, if the formatting of a file does not comply to the code style settings. 

I've tried to find formatting settings, that fit the current project, so that as few changes to the existing files have to be done as possible.


By executing the gradle task spotlessApply, the files are automatically formatted. At the moment, the user has to run this task by himself.

**Auto formatting in Eclipse**
Spotless internally uses Eclipses formatter, so Eclipse users could just import the code formatter options and the import order file from the projects base directory and use Eclipse's save actions to automatically apply the formatting on every save. I expect this to work pretty flawlessly, but I haven't tested this.

**Auto formatting in Intellij Idea**
For users of Idea I see only two options for automatic formatting, both of them are probably not ideal (suggestions for better solutions are very welcome):
1. Either import the formatting settings from the file spotless.eclipseformat.xml. I don't know, how well this works, as I could imagine that there are incompatibilities between Eclipse's and Idea's formatters. I haven't tested this, yet.
2. Or enable the setting to automatically save files before starting the build. Execute the spotlessApply task on every build (right click on the task in the view "Gradle project" and activate "Execute before Build"). Reassign Ctrl-S to "Build project" or use the current shortcut for "Build project" instead of saving. With all the obvious side effects.