### PR TITLE
Ignore empty lines in config file

### DIFF
--- a/src/test/java/io/kamax/matrix/client/MatrixHttpTest.java
+++ b/src/test/java/io/kamax/matrix/client/MatrixHttpTest.java
@@ -102,8 +102,9 @@ public class MatrixHttpTest {
         InputStream configFile = this.getClass().getResourceAsStream("/HomeserverTest.conf");
         if (configFile != null) {
             try (BufferedReader buffer = new BufferedReader(new InputStreamReader(configFile))) {
-                Map<String, String> configValues = buffer.lines().filter(line -> !line.startsWith("#")).collect(
-                        Collectors.toMap(line -> line.split("=")[0].trim(), line -> line.split("=")[1].trim()));
+                Map<String, String> configValues = buffer.lines()
+                        .filter(line -> !line.startsWith("#") && !line.isEmpty()).collect(
+                                Collectors.toMap(line -> line.split("=")[0].trim(), line -> line.split("=")[1].trim()));
 
                 port = Integer.valueOf(configValues.get("Port"));
                 hostname = configValues.get("Hostname");


### PR DESCRIPTION
Empty lines in the config file caused an exception instead of being just ignored