### PR TITLE
Set a timeout for http requests

### DIFF
--- a/src/main/java/io/kamax/matrix/client/MatrixHttpRequest.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixHttpRequest.java
@@ -20,6 +20,7 @@
 
 package io.kamax.matrix.client;
 
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 
 import java.util.ArrayList;
@@ -31,6 +32,14 @@ public class MatrixHttpRequest {
 
     public MatrixHttpRequest(HttpRequestBase request) {
         this.httpRequest = request;
+        RequestConfig.Builder configBuilder = request.getConfig().custom();
+        if (request.getConfig() != null) {
+            configBuilder = RequestConfig.copy(request.getConfig());
+        }
+        configBuilder.setConnectionRequestTimeout(2000);
+        configBuilder.setConnectTimeout(2000);
+        configBuilder.setSocketTimeout(2000);
+        httpRequest.setConfig(configBuilder.build());
     }
 
     public MatrixHttpRequest addIgnoredErrorCode(int errcode) {


### PR DESCRIPTION
Currently the SDK blocks and never returns if a server does not respond to a request. I had a situation in the wild while testing the login in my client, where this happened. And I have been able to simulate this behaviour with the new test case in this PR, see below.

To resolve this issue, I propose to introduce some timeout values as seen below. The current 2 second-delay is just a wild guess as to what I thought could be a practical value. I don't really know, which delay would be most sensible. The default implementation seems to never timeout. Some background information for the timeouts: http://www.baeldung.com/httpclient-timeout