### PR TITLE
Provide constructors to customise the Apache HTTP client (For #30)

### DIFF
--- a/src/main/java/io/kamax/matrix/client/MatrixClientDefaults.java
+++ b/src/main/java/io/kamax/matrix/client/MatrixClientDefaults.java
@@ -1,0 +1,59 @@
+/*
+ * matrix-java-sdk - Matrix Client SDK for Java
+ * Copyright (C) 2018 Kamax Sarl
+ *
+ * https://www.kamax.io/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.kamax.matrix.client;
+
+public class MatrixClientDefaults {
+
+    private int connectTimeout = 30 * 1000; // 30 sec
+    private int requestTimeout = 5 * 60 * 1000; // 5 min
+    private int socketTimeout = requestTimeout;
+
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public MatrixClientDefaults setConnectTimeout(int connectTimeout) {
+        this.connectTimeout = connectTimeout;
+
+        return this;
+    }
+
+    public int getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    public MatrixClientDefaults setRequestTimeout(int requestTimeout) {
+        this.requestTimeout = requestTimeout;
+
+        return this;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public MatrixClientDefaults setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
+
+        return this;
+    }
+
+}

--- a/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
+++ b/src/main/java/io/kamax/matrix/client/regular/MatrixHttpClient.java
@@ -37,6 +37,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.net.URI;
 import java.util.Optional;
@@ -49,6 +50,14 @@ public class MatrixHttpClient extends AMatrixHttpClient implements _MatrixClient
 
     public MatrixHttpClient(MatrixClientContext context) {
         super(context);
+    }
+
+    public MatrixHttpClient(MatrixClientContext context, MatrixClientDefaults defaults) {
+        super(context, defaults);
+    }
+
+    public MatrixHttpClient(MatrixClientContext context, CloseableHttpClient client) {
+        super(context, client);
     }
 
     protected _MatrixID getMatrixId(String localpart) {


### PR DESCRIPTION
Two new constructors:
- `MatrixHttpClient(MatrixClientContext context, MatrixClientDefaults defaults)`
- `MatrixHttpClient(MatrixClientContext context, CloseableHttpClient client)`